### PR TITLE
cni: use 0.3.1 cni version

### DIFF
--- a/services/node/containers.go
+++ b/services/node/containers.go
@@ -39,7 +39,7 @@ const (
 	defaultSnapshotter = "overlayfs"
 	defaultIfName      = "eth0"
 	cniLoopbackConf    = `{
-	"cniVersion": "0.4.0",
+	"cniVersion": "0.3.1",
 	"name": "loopback",
 	"type": "loopback",
         "ipam": {
@@ -53,7 +53,7 @@ const (
 }
 	`
 	cniConfTemplate = `{
-        "cniVersion": "0.4.0",
+        "cniVersion": "0.3.1",
         "name": "stellar",
         "type": "bridge",
         "bridge": "{{.Bridge}}",


### PR DESCRIPTION
- version 0.4.0 is still in dev'
- doesn't seem it is required either

:angel: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>