### PR TITLE
wip: add a way to add additionnal dir for cni plugins dir lookup

### DIFF
--- a/cmd/stellar/server.go
+++ b/cmd/stellar/server.go
@@ -114,6 +114,11 @@ var serverCommand = cli.Command{
 			Usage: "one or more peers for agent to join",
 			Value: &cli.StringSlice{},
 		},
+		cli.StringFlag{
+			Name:  "cniBinPath",
+			Usage: "path to look for cni binaries",
+			Value: "",
+		},
 	},
 }
 
@@ -155,6 +160,7 @@ func serverAction(c *cli.Context) error {
 		ProxyHTTPSPort:           c.Int("proxy-https-port"),
 		ProxyTLSEmail:            c.String("proxy-tls-email"),
 		ProxyHealthcheckInterval: c.Duration("proxy-healthcheck-interval"),
+		CNIBinPath:               c.String("cniBinPath"),
 	})
 	if err != nil {
 		return err

--- a/config.go
+++ b/config.go
@@ -20,4 +20,5 @@ type Config struct {
 	ProxyHTTPSPort           int
 	ProxyTLSEmail            string
 	ProxyHealthcheckInterval time.Duration
+	CNIBinPath               string
 }

--- a/services/node/containers.go
+++ b/services/node/containers.go
@@ -575,8 +575,12 @@ func (s *service) getNetworkConf() ([]byte, error) {
 }
 
 func (s *service) getNetwork(opts ...gocni.CNIOpt) (gocni.CNI, error) {
+	pluginDirs := []string{"/opt/containerd/bin", "/opt/cni/bin"}
+	if s.cniBinDir != "" {
+		pluginDirs = append(pluginDirs, s.cniBinDir)
+	}
 	network, err := gocni.New(
-		gocni.WithPluginDir([]string{"/opt/containerd/bin", "/opt/cni/bin"}))
+		gocni.WithPluginDir(pluginDirs))
 	if err != nil {
 		return nil, err
 	}

--- a/services/node/service.go
+++ b/services/node/service.go
@@ -19,6 +19,7 @@ type service struct {
 	bridge         string
 	dataDir        string
 	stateDir       string
+	cniBinDir      string
 	agent          *element.Agent
 }
 
@@ -29,6 +30,7 @@ func New(cfg *stellar.Config, agent *element.Agent) (*service, error) {
 		bridge:         cfg.Bridge,
 		dataDir:        cfg.DataDir,
 		stateDir:       cfg.StateDir,
+		cniBinDir:      cfg.CNIBinPath,
 		agent:          agent,
 	}, nil
 }


### PR DESCRIPTION
Main reason, using `nixos`, my `cni-plugins` binairies are not in `/opt/cni`. This adds a way to add a folder in the CNI binary lookup paths.

Things I'm not sure of

- [ ] flag or using `$PATH` values ?
- [ ] one or multiple values ?
- [ ] name ? (this name is not really great)

Signed-off-by: Vincent Demeester <vincent@sbr.pm>