### PR TITLE
Move context cancel into grpc-gateway goroutine

### DIFF
--- a/services/gateway/service.go
+++ b/services/gateway/service.go
@@ -43,7 +43,6 @@ func (s *service) ID() string {
 func (s *service) Start() error {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	mux := runtime.NewServeMux()
 	opts := []grpc.DialOption{grpc.WithInsecure()}
@@ -60,6 +59,7 @@ func (s *service) Start() error {
 	}).Info("starting http gateway")
 
 	go func() {
+		defer cancel()
 		if err := http.ListenAndServe(fmt.Sprintf("%s:%d", s.gatewayAddr, s.gatewayPort), mux); err != nil {
 			logrus.Error(err)
 		}


### PR DESCRIPTION
As the grpc-gateway http server is running in a goroutine, we need to
ensure that the context cancel is deferred until after the http server
stops running. I believe that at the moment, the http server starts in
the goroutine and then shortly after we call a deferred context cancel
at the end of the service's Start function call.