### PR TITLE
TLS support for GRPC in server and client

### DIFF
--- a/client/network.go
+++ b/client/network.go
@@ -7,6 +7,7 @@ import (
 
 	networkapi "github.com/ehazlett/stellar/api/services/network/v1"
 	ptypes "github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
 )
 
 type network struct {
@@ -29,7 +30,7 @@ func (n *network) AllocateSubnet(node string) (string, error) {
 		Node: node,
 	})
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "error making request")
 	}
 
 	return resp.SubnetCIDR, nil

--- a/config.go
+++ b/config.go
@@ -17,6 +17,16 @@ type Config struct {
 	NodeID string
 	// GRPCAddress is the address for the grpc server
 	GRPCAddress string
+	// TLSCertificate is the certificate used for grpc communication
+	TLSServerCertificate string
+	// TLSKey is the key used for grpc communication
+	TLSServerKey string
+	// TLSClientCertificate is the client certificate used for communication
+	TLSClientCertificate string
+	// TLSClientKey is the client key used for communication
+	TLSClientKey string
+	// TLSInsecureSkipVerify disables certificate verification
+	TLSInsecureSkipVerify bool
 	// AgentConfig is the element config for the server
 	AgentConfig *element.Config `json:"-"`
 	// ContainerdAddr is the address to the containerd socket

--- a/services/application/create.go
+++ b/services/application/create.go
@@ -12,7 +12,7 @@ import (
 func (s *service) Create(ctx context.Context, req *api.CreateRequest) (*ptypes.Empty, error) {
 	appName := getAppName(req.Name)
 	logrus.Debugf("creating application %s", appName)
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return empty, err
 	}
@@ -48,7 +48,7 @@ func (s *service) Create(ctx context.Context, req *api.CreateRequest) (*ptypes.E
 	for _, service := range services {
 		// get random peer for deploy
 		node := nodes[nodeIdx]
-		nc, err := s.nodeClient(node.ID)
+		nc, err := s.client(node.Address)
 		if err != nil {
 			return empty, err
 		}

--- a/services/application/delete.go
+++ b/services/application/delete.go
@@ -17,7 +17,7 @@ var (
 )
 
 func (s *service) Delete(ctx context.Context, req *api.DeleteRequest) (*ptypes.Empty, error) {
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (s *service) Delete(ctx context.Context, req *api.DeleteRequest) (*ptypes.E
 			continue
 		}
 		logrus.Debugf("app delete: deleting container %s", id)
-		nc, err := s.nodeClient(cc.Node.ID)
+		nc, err := s.client(cc.Node.Address)
 		if err != nil {
 			logrus.Warnf("delete: error getting client for node %s: %s", cc.Node.ID, err)
 			continue

--- a/services/application/get.go
+++ b/services/application/get.go
@@ -23,7 +23,7 @@ func (s *service) Get(ctx context.Context, req *api.GetRequest) (*api.GetRespons
 }
 
 func (s *service) getApp(ctx context.Context, name string) (*api.App, error) {
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return nil, err
 	}

--- a/services/application/helpers.go
+++ b/services/application/helpers.go
@@ -42,7 +42,7 @@ func (s *service) containerToService(ctx context.Context, c *clusterapi.Containe
 }
 
 func (s *service) getApplicationContainers(name string) ([]*clusterapi.Container, error) {
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return nil, err
 	}

--- a/services/application/list.go
+++ b/services/application/list.go
@@ -18,7 +18,7 @@ func (a AppSorter) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
 func (s *service) List(ctx context.Context, req *api.ListRequest) (*api.ListResponse, error) {
 	// filter containers for application label
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return nil, err
 	}

--- a/services/application/restart.go
+++ b/services/application/restart.go
@@ -27,7 +27,7 @@ func (s *service) Restart(ctx context.Context, req *api.RestartRequest) (*ptypes
 			continue
 		}
 		logrus.Debugf("restarting container %s on node %s", cc.Container.ID, cc.Node.ID)
-		nc, err := s.nodeClient(cc.Node.ID)
+		nc, err := s.client(cc.Node.Address)
 		if err != nil {
 			logrus.Warnf("delete: error getting client for node %s: %s", cc.Node.ID, err)
 			continue

--- a/services/cluster/containers.go
+++ b/services/cluster/containers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	api "github.com/ehazlett/stellar/api/services/cluster/v1"
-	"github.com/ehazlett/stellar/client"
 )
 
 func (s *service) Containers(ctx context.Context, req *api.ContainersRequest) (*api.ContainersResponse, error) {
@@ -16,7 +15,7 @@ func (s *service) Containers(ctx context.Context, req *api.ContainersRequest) (*
 	}
 
 	for _, node := range resp.Nodes {
-		c, err := client.NewClient(node.Address)
+		c, err := s.client(node.Address)
 		if err != nil {
 			return nil, err
 		}

--- a/services/cluster/health.go
+++ b/services/cluster/health.go
@@ -5,7 +5,6 @@ import (
 
 	api "github.com/ehazlett/stellar/api/services/cluster/v1"
 	healthapi "github.com/ehazlett/stellar/api/services/health/v1"
-	"github.com/ehazlett/stellar/client"
 	ptypes "github.com/gogo/protobuf/types"
 )
 
@@ -17,7 +16,7 @@ func (s *service) Health(ctx context.Context, req *api.HealthRequest) (*api.Heal
 
 	status := map[*api.Node]*healthapi.HealthResponse{}
 	for _, node := range nodes {
-		nc, err := client.NewClient(node.Address)
+		nc, err := s.client(node.Address)
 		if err != nil {
 			return nil, err
 		}

--- a/services/cluster/service.go
+++ b/services/cluster/service.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ehazlett/element"
 	"github.com/ehazlett/stellar"
 	api "github.com/ehazlett/stellar/api/services/cluster/v1"
+	"github.com/ehazlett/stellar/client"
 	"google.golang.org/grpc"
 )
 
@@ -16,6 +17,7 @@ type service struct {
 	containerdAddr string
 	namespace      string
 	agent          *element.Agent
+	config         *stellar.Config
 }
 
 func New(cfg *stellar.Config, a *element.Agent) (*service, error) {
@@ -23,6 +25,7 @@ func New(cfg *stellar.Config, a *element.Agent) (*service, error) {
 		containerdAddr: cfg.ContainerdAddr,
 		namespace:      cfg.Namespace,
 		agent:          a,
+		config:         cfg,
 	}, nil
 }
 
@@ -65,4 +68,12 @@ func (s *service) nodes() ([]*api.Node, error) {
 	}
 
 	return nodes, nil
+}
+
+func (s *service) client(address string) (*client.Client, error) {
+	opts, err := client.DialOptionsFromConfig(s.config)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewClient(address, opts...)
 }

--- a/services/datastore/service.go
+++ b/services/datastore/service.go
@@ -27,6 +27,7 @@ var (
 
 type service struct {
 	agent                 *element.Agent
+	config                *stellar.Config
 	dir                   string
 	lock                  *sync.Mutex
 	lockChan              chan bool
@@ -44,6 +45,7 @@ type tombstone struct {
 func New(cfg *stellar.Config, a *element.Agent) (*service, error) {
 	svc := &service{
 		agent:                 a,
+		config:                cfg,
 		dir:                   cfg.DataDir,
 		lock:                  &sync.Mutex{},
 		lockChan:              make(chan bool),
@@ -143,7 +145,10 @@ func (s *service) openDB() (*bolt.DB, error) {
 	return db, nil
 }
 
-func (s *service) client() (*client.Client, error) {
-	peer := s.agent.Self()
-	return client.NewClient(peer.Address)
+func (s *service) client(address string) (*client.Client, error) {
+	opts, err := client.DialOptionsFromConfig(s.config)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewClient(address, opts...)
 }

--- a/services/datastore/sync.go
+++ b/services/datastore/sync.go
@@ -7,7 +7,6 @@ import (
 
 	bolt "github.com/coreos/bbolt"
 	api "github.com/ehazlett/stellar/api/services/datastore/v1"
-	"github.com/ehazlett/stellar/client"
 	ptypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -80,7 +79,7 @@ func (s *service) Sync(_ *api.SyncRequest, srv api.Datastore_SyncServer) error {
 // PeerSync issues the local node to sync with the requested peer
 func (s *service) PeerSync(ctx context.Context, req *api.PeerSyncRequest) (*ptypes.Empty, error) {
 	logrus.Debugf("performing datastore sync with peer %s", req.ID)
-	c, err := client.NewClient(req.Address)
+	c, err := s.client(req.Address)
 	if err != nil {
 		return empty, err
 	}
@@ -135,7 +134,7 @@ func (s *service) replicateToPeers(ctx context.Context) error {
 
 	for _, peer := range peers {
 		logrus.Debugf("performing sync with peer %s", peer.ID)
-		c, err := client.NewClient(peer.Address)
+		c, err := s.client(peer.Address)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{
 				"peer": peer.ID,

--- a/services/nameserver/create.go
+++ b/services/nameserver/create.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *service) Create(ctx context.Context, req *api.CreateRequest) (*ptypes.Empty, error) {
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return nil, err
 	}

--- a/services/nameserver/delete.go
+++ b/services/nameserver/delete.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *service) Delete(ctx context.Context, req *api.DeleteRequest) (*ptypes.Empty, error) {
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return empty, err
 	}

--- a/services/nameserver/dns.go
+++ b/services/nameserver/dns.go
@@ -42,7 +42,7 @@ func (s *service) startDNSServer() error {
 }
 
 func (s *service) gateway() (net.IP, error) {
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return nil, err
 	}

--- a/services/nameserver/list.go
+++ b/services/nameserver/list.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *service) List(ctx context.Context, req *api.ListRequest) (*api.ListResponse, error) {
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return nil, err
 	}

--- a/services/nameserver/lookup.go
+++ b/services/nameserver/lookup.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *service) Lookup(ctx context.Context, req *api.LookupRequest) (*api.LookupResponse, error) {
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return nil, err
 	}

--- a/services/nameserver/service.go
+++ b/services/nameserver/service.go
@@ -26,6 +26,7 @@ type service struct {
 	bridge          string
 	upstreamDNSAddr string
 	agent           *element.Agent
+	config          *stellar.Config
 }
 
 func New(cfg *stellar.Config, agent *element.Agent) (*service, error) {
@@ -35,6 +36,7 @@ func New(cfg *stellar.Config, agent *element.Agent) (*service, error) {
 		bridge:          cfg.Bridge,
 		upstreamDNSAddr: cfg.UpstreamDNSAddr,
 		agent:           agent,
+		config:          cfg,
 	}
 
 	return srv, nil
@@ -57,7 +59,10 @@ func (s *service) containerd() (*containerd.Client, error) {
 	return stellar.DefaultContainerd(s.containerdAddr, s.namespace)
 }
 
-func (s *service) client() (*client.Client, error) {
-	peer := s.agent.Self()
-	return client.NewClient(peer.Address)
+func (s *service) client(address string) (*client.Client, error) {
+	opts, err := client.DialOptionsFromConfig(s.config)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewClient(address, opts...)
 }

--- a/services/network/service.go
+++ b/services/network/service.go
@@ -28,12 +28,14 @@ type service struct {
 	network *net.IPNet
 	agent   *element.Agent
 	ds      datastoreapi.DatastoreServer
+	config  *stellar.Config
 }
 
 func New(cfg *stellar.Config, agent *element.Agent, ds datastoreapi.DatastoreServer) (*service, error) {
 	return &service{
 		network: cfg.Subnet,
 		agent:   agent,
+		config:  cfg,
 		ds:      ds,
 	}, nil
 }
@@ -51,7 +53,10 @@ func (s *service) Start() error {
 	return nil
 }
 
-func (s *service) client() (*client.Client, error) {
-	peer := s.agent.Self()
-	return client.NewClient(peer.Address)
+func (s *service) client(address string) (*client.Client, error) {
+	opts, err := client.DialOptionsFromConfig(s.config)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewClient(address, opts...)
 }

--- a/services/network/subnet.go
+++ b/services/network/subnet.go
@@ -24,6 +24,7 @@ var (
 )
 
 func (s *service) AllocateSubnet(ctx context.Context, req *api.AllocateSubnetRequest) (*api.AllocateSubnetResponse, error) {
+	logrus.Debug("service.network allocating subnet")
 	// check for existing assigned subnet; if not, allocate
 	localSubnetKey := fmt.Sprintf(dsSubnetsKey, req.Node)
 

--- a/services/node/containers.go
+++ b/services/node/containers.go
@@ -270,7 +270,7 @@ func (s *service) CreateContainer(ctx context.Context, req *api.CreateContainerR
 	}
 
 	// update dns
-	c, err := s.client()
+	c, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return empty, err
 	}
@@ -371,7 +371,7 @@ func (s *service) DeleteContainer(ctx context.Context, req *api.DeleteContainerR
 	}
 	defer c.Close()
 
-	client, err := s.client()
+	client, err := s.client(s.agent.Self().Address)
 	if err != nil {
 		return empty, err
 	}

--- a/services/node/service.go
+++ b/services/node/service.go
@@ -21,6 +21,7 @@ type service struct {
 	stateDir       string
 	cniBinPaths    []string
 	agent          *element.Agent
+	config         *stellar.Config
 }
 
 func New(cfg *stellar.Config, agent *element.Agent) (*service, error) {
@@ -32,6 +33,7 @@ func New(cfg *stellar.Config, agent *element.Agent) (*service, error) {
 		stateDir:       cfg.StateDir,
 		cniBinPaths:    cfg.CNIBinPaths,
 		agent:          agent,
+		config:         cfg,
 	}, nil
 }
 
@@ -52,9 +54,12 @@ func (s *service) containerd() (*containerd.Client, error) {
 	return stellar.DefaultContainerd(s.containerdAddr, s.namespace)
 }
 
-func (s *service) client() (*client.Client, error) {
-	peer := s.agent.Self()
-	return client.NewClient(peer.Address)
+func (s *service) client(address string) (*client.Client, error) {
+	opts, err := client.DialOptionsFromConfig(s.config)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewClient(address, opts...)
 }
 
 func (s *service) peerAddr() (string, error) {

--- a/services/proxy/backend.go
+++ b/services/proxy/backend.go
@@ -34,7 +34,7 @@ func (s *service) Backends(ctx context.Context, req *api.BackendRequest) (*api.B
 
 func (s *service) loadUpstream(upstream string) *api.Upstream {
 	status := "up"
-	latency, err := checkConnection(upstream, s.cfg.ProxyHealthcheckInterval)
+	latency, err := checkConnection(upstream, s.config.ProxyHealthcheckInterval)
 	if err != nil {
 		latency = time.Millisecond * 0
 		status = err.Error()


### PR DESCRIPTION
This adds TLS support for the GRPC backend.  The following options are supported:

- `TLSServerCertificate`: (required) path to the certificate for the server
- `TLSServerKey`: (required) path to the key for the server
- `TLSClientCertificate`: (required) path to the client certificate
- `TLSClientKey`: (optional) path to the key for the client
- `TLSInsecureSkipVerify`: boolean to disable tls verification

Note: for a quick setup you can generate a self-signed certificate and use the cert and key for both the server and client as long as verification is disabled.

Example Config

```json
    "TLSServerCertificate": "/etc/certs/server.crt",
    "TLSServerKey": "/etc/certs/server.key",
    "TLSClientCertificate": "/etc/certs/client-00.crt",
    "TLSClientKey": "/etc/certs/client-00.key",
    "TLSInsecureSkipVerify": true,
```

If the options are left as empty strings (`""`) or removed from the config, TLS is disabled.