### PR TITLE
Improve subnet allocation for nodes

### DIFF
--- a/services/network/helpers.go
+++ b/services/network/helpers.go
@@ -8,8 +8,13 @@ import (
 
 // adapted from https://github.com/kubernetes/kops/blob/master/upup/pkg/fi/cloudup/subnets.go
 func divideSubnet(sub *net.IPNet, maxSubnets int) ([]*net.IPNet, error) {
-	length, _ := sub.Mask.Size()
-	length += 10
+	subnetSize, _ := sub.Mask.Size()
+	length := subnetSize + subnetMaskBits
+
+	// check for network smaller than /24
+	if subnetSize > 21 {
+		return nil, fmt.Errorf("subnet must be larger than /22")
+	}
 
 	var subnets []*net.IPNet
 	for i := 0; i < maxSubnets; i++ {

--- a/services/network/helpers_test.go
+++ b/services/network/helpers_test.go
@@ -5,7 +5,37 @@ import (
 	"testing"
 )
 
-func TestNetworkSubdivide172(t *testing.T) {
+func TestNetworkSubdivide10Slash8(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("10.0.0.0/8")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxSubnets := 1024
+
+	subnets, err := divideSubnet(ipnet, maxSubnets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v := len(subnets); v != maxSubnets {
+		t.Fatalf("expected %d subnets; received %d", maxSubnets, v)
+	}
+	testSub1 := subnets[0]
+	testIP1 := net.IPv4(10, 0, 0, 42)
+	testSub2 := subnets[len(subnets)-1]
+	testIP2 := net.IPv4(10, 255, 255, 42)
+
+	if !testSub1.Contains(testIP1) {
+		t.Fatalf("expected ip %s in subnet %s", testIP1.String(), testSub1)
+	}
+
+	if !testSub2.Contains(testIP2) {
+		t.Fatalf("expected ip %s in subnet %s", testIP2.String(), testSub2)
+	}
+}
+
+func TestNetworkSubdivide172Slash12(t *testing.T) {
 	_, ipnet, err := net.ParseCIDR("172.16.0.0/12")
 	if err != nil {
 		t.Fatal(err)
@@ -27,16 +57,16 @@ func TestNetworkSubdivide172(t *testing.T) {
 	testIP2 := net.IPv4(172, 31, 252, 42)
 
 	if !testSub1.Contains(testIP1) {
-		t.Fatalf("expected ip %s in subnet %s", string(testIP1), testSub1)
+		t.Fatalf("expected ip %s in subnet %s", testIP1.String(), testSub1)
 	}
 
 	if !testSub2.Contains(testIP2) {
-		t.Fatalf("expected ip %s in subnet %s", string(testIP2), testSub2)
+		t.Fatalf("expected ip %s in subnet %s", testIP2.String(), testSub2)
 	}
 }
 
-func TestNetworkSubdivide10(t *testing.T) {
-	_, ipnet, err := net.ParseCIDR("10.0.0.0/8")
+func TestNetworkSubdivide172Slash16(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("172.16.0.0/16")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,15 +82,207 @@ func TestNetworkSubdivide10(t *testing.T) {
 		t.Fatalf("expected %d subnets; received %d", maxSubnets, v)
 	}
 	testSub1 := subnets[0]
-	testIP1 := net.IPv4(10, 0, 0, 42)
+	testIP1 := net.IPv4(172, 16, 0, 42)
 	testSub2 := subnets[len(subnets)-1]
-	testIP2 := net.IPv4(10, 255, 192, 42)
+	testIP2 := net.IPv4(172, 16, 255, 254)
 
 	if !testSub1.Contains(testIP1) {
-		t.Fatalf("expected ip %s in subnet %s", string(testIP1), testSub1)
+		t.Fatalf("expected ip %s in subnet %s", testIP1.String(), testSub1)
 	}
 
 	if !testSub2.Contains(testIP2) {
-		t.Fatalf("expected ip %s in subnet %s", string(testIP2), testSub2)
+		t.Fatalf("expected ip %s in subnet %s", testIP2.String(), testSub2)
+	}
+}
+
+func TestNetworkSubdivide172Slash17(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("172.16.0.0/17")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxSubnets := 1024
+
+	subnets, err := divideSubnet(ipnet, maxSubnets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v := len(subnets); v != maxSubnets {
+		t.Fatalf("expected %d subnets; received %d", maxSubnets, v)
+	}
+	testSub1 := subnets[0]
+	testIP1 := net.IPv4(172, 16, 0, 10)
+	testSub2 := subnets[len(subnets)-1]
+	testIP2 := net.IPv4(172, 16, 127, 254)
+
+	if !testSub1.Contains(testIP1) {
+		t.Fatalf("expected ip %s in subnet %s", testIP1.String(), testSub1)
+	}
+
+	if !testSub2.Contains(testIP2) {
+		t.Fatalf("expected ip %s in subnet %s", testIP2.String(), testSub2)
+	}
+}
+
+func TestNetworkSubdivide172Slash18(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("172.16.0.0/18")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxSubnets := 1024
+
+	subnets, err := divideSubnet(ipnet, maxSubnets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v := len(subnets); v != maxSubnets {
+		t.Fatalf("expected %d subnets; received %d", maxSubnets, v)
+	}
+	testSub1 := subnets[0]
+	testIP1 := net.IPv4(172, 16, 0, 10)
+	testSub2 := subnets[len(subnets)-1]
+	testIP2 := net.IPv4(172, 16, 63, 254)
+
+	if !testSub1.Contains(testIP1) {
+		t.Fatalf("expected ip %s in subnet %s", testIP1.String(), testSub1)
+	}
+
+	if !testSub2.Contains(testIP2) {
+		t.Fatalf("expected ip %s in subnet %s", testIP2.String(), testSub2)
+	}
+}
+
+func TestNetworkSubdivide172Slash19(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("172.16.0.0/19")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxSubnets := 1024
+
+	subnets, err := divideSubnet(ipnet, maxSubnets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v := len(subnets); v != maxSubnets {
+		t.Fatalf("expected %d subnets; received %d", maxSubnets, v)
+	}
+	testSub1 := subnets[0]
+	testIP1 := net.IPv4(172, 16, 0, 1)
+	testSub2 := subnets[len(subnets)-1]
+	testIP2 := net.IPv4(172, 16, 31, 254)
+
+	if !testSub1.Contains(testIP1) {
+		t.Fatalf("expected ip %s in subnet %s", testIP1.String(), testSub1)
+	}
+
+	if !testSub2.Contains(testIP2) {
+		t.Fatalf("expected ip %s in subnet %s", testIP2.String(), testSub2)
+	}
+}
+
+func TestNetworkSubdivide172Slash20(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("172.16.0.0/20")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxSubnets := 1024
+
+	subnets, err := divideSubnet(ipnet, maxSubnets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v := len(subnets); v != maxSubnets {
+		t.Fatalf("expected %d subnets; received %d", maxSubnets, v)
+	}
+	testSub1 := subnets[0]
+	testIP1 := net.IPv4(172, 16, 0, 1)
+	testSub2 := subnets[len(subnets)-1]
+	testIP2 := net.IPv4(172, 16, 15, 254)
+
+	if !testSub1.Contains(testIP1) {
+		t.Fatalf("expected ip %s in subnet %s", testIP1.String(), testSub1)
+	}
+
+	if !testSub2.Contains(testIP2) {
+		t.Fatalf("expected ip %s in subnet %s", testIP2.String(), testSub2)
+	}
+}
+
+func TestNetworkSubdivide172Slash21(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("172.16.0.0/21")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxSubnets := 1024
+
+	subnets, err := divideSubnet(ipnet, maxSubnets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v := len(subnets); v != maxSubnets {
+		t.Fatalf("expected %d subnets; received %d", maxSubnets, v)
+	}
+	testSub1 := subnets[0]
+	testIP1 := net.IPv4(172, 16, 0, 1)
+	testSub2 := subnets[len(subnets)-1]
+	testIP2 := net.IPv4(172, 16, 7, 254)
+
+	if !testSub1.Contains(testIP1) {
+		t.Fatalf("expected ip %s in subnet %s", testIP1.String(), testSub1)
+	}
+
+	if !testSub2.Contains(testIP2) {
+		t.Fatalf("expected ip %s in subnet %s", testIP2.String(), testSub2)
+	}
+}
+
+func TestNetworkSubdivide172Slash22(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("172.16.0.0/22")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxSubnets := 1024
+
+	_, err = divideSubnet(ipnet, maxSubnets)
+	if err == nil {
+		t.Fatal("expected error for /22 subnet")
+	}
+}
+
+func TestNetworkSubdivide172Slash23(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("172.16.0.0/23")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxSubnets := 1024
+
+	_, err = divideSubnet(ipnet, maxSubnets)
+	if err == nil {
+		t.Fatal("expected error for /23 subnet")
+	}
+}
+
+func TestNetworkSubdivide192Slash24(t *testing.T) {
+	_, ipnet, err := net.ParseCIDR("192.168.0.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxSubnets := 1024
+
+	_, err = divideSubnet(ipnet, maxSubnets)
+	if err == nil {
+		t.Fatal("expected error for /24 subnet")
 	}
 }

--- a/services/network/service.go
+++ b/services/network/service.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"net"
 
-	"github.com/stellarproject/element"
 	"github.com/ehazlett/stellar"
 	api "github.com/ehazlett/stellar/api/services/network/v1"
 	"github.com/ehazlett/stellar/client"
 	"github.com/ehazlett/stellar/services"
 	ptypes "github.com/gogo/protobuf/types"
+	"github.com/stellarproject/element"
 	"google.golang.org/grpc"
 )
 
@@ -18,6 +18,7 @@ const (
 	// TODO: make configurable
 	// default max subnets (max nodes)
 	maxSubnets          = 1024
+	subnetMaskBits      = 10
 	dsNetworkBucketName = "stellar." + stellar.APIVersion + ".services.network"
 )
 


### PR DESCRIPTION
This adds the ability to detect subnet changes in the configuration
as well as properly return errors when too small of subnet is
requested in the config (less than /22).  Since the network is an
additional network and nodes are routers we require that it be at least
a /21 to properly allow for a suitable number of network enabled
containers per host.

This also removes all addresses on the Stellar bridge interface to ensure
that no stale IPs are left assigned.

Fixes #23 

/cc @mabunixda

Signed-off-by: Evan Hazlett <ejhazlett@gmail.com>